### PR TITLE
Code Quality: Removed unnecessary files from GitHub statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,3 +44,6 @@ tests/suite/file_without_BOM.txt -text
 
 # Do not normalize on commit.
 *.pdf -text
+
+*.pck linguist-detectable=false
+*.html linguist-documentation=true


### PR DESCRIPTION
@BCSharp while you're fixing this, might as well make this change.

---

This hides files from showing up in GitHub here:
![image](https://github.com/user-attachments/assets/cead9079-a811-4c3c-90c8-d283a4f913a2)

IronPython doesn't use PSQL significantly enough for it to be detected, and HTML is used only for the documentation, which GitHub automatically enables filters for (that seem to not be working).
